### PR TITLE
Fix misnamed variable to make it work

### DIFF
--- a/deploy_vcl
+++ b/deploy_vcl
@@ -108,8 +108,8 @@ end
 @f = Fastly.new({ :user => username, :password => password })
 config['git_version'] = get_git_version
 
-configuration = @f.get_service(config['service_id'])
-version = get_dev_version(configuration)
+service = @f.get_service(config['service_id'])
+version = get_dev_version(service)
 puts "Using version: #{version.number}"
 
 vcl = render_vcl(configuration, environment, config)


### PR DESCRIPTION
Without this change, attempting to deploy vcl dies with something like:

Using version: 12
./deploy_vcl:62:in `read': No such file or directory - ./vcl_templates/#<Fastly::Service:0x00123458>.vcl.erb (Errno::ENOENT)
    from ./deploy_vcl:62:in`render_vcl'
    from ./deploy_vcl:115:in `<main>'
