### PR TITLE
Update Ruby version prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ YAML files, using Fastly's [API](https://docs.fastly.com/api/).
 
 To run Fastly Configure, you'll need:
 
-  - Ruby 2.0.0 or later
+  - Ruby 2.1.8 or later
   - Bundler 1.5.3 or later
   - a Fastly account
 


### PR DESCRIPTION
The .ruby-version file was updated in
16d8b86e382ac6ce84293a65698e6672d75c09b7, but this README wasn't.

Does that.
