### PR TITLE
Use active? instead of internal representation

### DIFF
--- a/deploy_vcl
+++ b/deploy_vcl
@@ -29,7 +29,7 @@ end
 def get_dev_version(configuration)
   # Sometimes the latest version isn't the development version.
   version = configuration.version
-  version = version.clone if version.active == "1"
+  version = version.clone if version.active?
 
   version
 end
@@ -77,7 +77,7 @@ def upload_vcl(version, contents)
 end
 
 def diff_vcl(configuration, version_new)
-  version_current = configuration.versions.find { |v| v.active == '1' }
+  version_current = configuration.versions.find { |v| v.active? }
   diff = Diffy::Diff.new(
     version_current.generated_vcl.content,
     version_new.generated_vcl.content,


### PR DESCRIPTION
In the Fastly API, version.active has changed from being a "0" or "1" to
being a boolean like it should always have been.

Use active? provided by the fastly library rather than depending on the
internal representation.

See https://github.com/fastly/fastly-ruby/pull/81
