### PR TITLE
Check for boolean value to version.active

### DIFF
--- a/deploy_vcl
+++ b/deploy_vcl
@@ -29,7 +29,7 @@ end
 def get_dev_version(configuration)
   # Sometimes the latest version isn't the development version.
   version = configuration.version
-  version = version.clone if version.active == "1"
+  version = version.clone if version.active == "true"
 
   version
 end
@@ -77,7 +77,7 @@ def upload_vcl(version, contents)
 end
 
 def diff_vcl(configuration, version_new)
-  version_current = configuration.versions.find { |v| v.active == '1' }
+  version_current = configuration.versions.find { |v| v.active == 'true' }
   diff = Diffy::Diff.new(
     version_current.generated_vcl.content,
     version_new.generated_vcl.content,


### PR DESCRIPTION
version.active returns a boolean value rather than an integer, according to
the Fastly API documentation for the Service method at
https://docs.fastly.com/api/config#service.

When checking whether or not a service is active, looking for a 1 results in
undefined value errors during diff_vcl, whereas checking for 'true' resolves
these and matches the API documentation.
