### PR TITLE
[DO NOT MERGE] Use one-time password for deployment

### DIFF
--- a/deploy_vcl
+++ b/deploy_vcl
@@ -1,8 +1,13 @@
 #!/usr/bin/env ruby
 
+require 'cgi'
 require 'diffy'
 require 'erb'
 require 'fastly'
+require 'json'
+require 'net/http'
+require 'net/https'
+require 'time'
 require 'yaml'
 
 CONFIGS = YAML.load_file(File.join(__dir__, "fastly.yaml"))
@@ -103,7 +108,7 @@ end
 
 configuration, environment, config = get_config(ARGV)
 
-['FASTLY_USER', 'FASTLY_PASS'].each do |envvar|
+['FASTLY_USER', 'FASTLY_PASS', 'FASTLY_OTP'].each do |envvar|
   if ENV[envvar].nil?
     raise "#{envvar} is not set in the environment"
   end
@@ -111,8 +116,21 @@ end
 
 username = ENV['FASTLY_USER']
 password = ENV['FASTLY_PASS']
+passcode = ENV['FASTLY_OTP']
 
-@f = Fastly.new({ :user => username, :password => password })
+http = Net::HTTP.new('api.fastly.com', 443)
+http.use_ssl = true
+
+token_expires = CGI.escape((Time.now + (60 * 20)).iso8601)
+
+data = "username=#{username}&password=#{password}&expires_at=#{token_expires}"
+headers = {'Fastly-OTP' => passcode}
+
+resp = http.post('/tokens', data, headers)
+
+token = JSON.load(resp.body)['access_token']
+
+@f = Fastly.new({ :api_key => token })
 config['git_version'] = get_git_version
 
 service = @f.get_service(config['service_id'])


### PR DESCRIPTION
This commit introduces an additional environment variable which is the one-time password generated by 2 factor authentication.

The Fastly gem doesn't support the tokens endpoint yet but once it does we should refactor this to use it.

I've generated a token which is valid for 20 minutes and then use that token for all the API requests.

This means that we can remove the user account we have which only exists for deployment, and we can use our personal accounts which have 2FA enabled. This is better for auditing who changed things and for security.

---

Needs more testing before it can be merged.
