### PR TITLE
Push to release branches after deploy

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,3 +10,11 @@ cp govuk-cdn-config/vcl_templates/*.vcl.erb vcl_templates/
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec ./deploy_vcl ${vhost} ${ENVIRONMENT}
+
+cd cdn-configs
+git push -f git@github.gds:gds/cdn-configs.git HEAD:refs/heads/deployed-to-${ENVIRONMENT}
+
+cd ..
+
+cd govuk-cdn-config
+git push -f git@github.com:alphagov/govuk-cdn-config.git HEAD:refs/heads/deployed-to-${ENVIRONMENT}


### PR DESCRIPTION
At the moment we don't know what's deployed to staging or production. This commit adds a step to push to the deployed-to-staging and deployed-to-production branches after each deploy. This will enable us to compare the currently deployed version. It's consistent with what we do in govuk-app-deployment:

https://github.com/alphagov/govuk-app-deployment/blob/64941e7f0ca4b78ba6bc745dc8dd9b369c6931d8/recipes/defaults.rb#L189

Related ticket: https://trello.com/c/g4C5JaTU