### PR TITLE
Revert "Push to release branches after deploy"

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,11 +10,3 @@ cp govuk-cdn-config/vcl_templates/*.vcl.erb vcl_templates/
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec ./deploy_vcl ${vhost} ${ENVIRONMENT}
-
-cd cdn-configs
-git push -f git@github.gds:gds/cdn-configs.git HEAD:refs/heads/deployed-to-${ENVIRONMENT}
-
-cd ..
-
-cd govuk-cdn-config
-git push -f git@github.com:alphagov/govuk-cdn-config.git HEAD:refs/heads/deployed-to-${ENVIRONMENT}


### PR DESCRIPTION
Reverts alphagov/fastly-configure#15.

This PR didn't make any sense, because the task to deploy the CDN takes a "service" as argument. This means that you can deploy `www`, but not `tldredirect`. Having these deployed-to-x branches will mistakenly imply that you've deployed all VCL templates. 