### PR TITLE
Exit the deploy script when subcommand fails

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 git clone 'git@github.gds:gds/cdn-configs.git'
 
 cp cdn-configs/fastly/fastly.yaml .


### PR DESCRIPTION
`set -e` will exit the script when one of the commands fails. This prevents further commands from being executed and makes sure the right exit code is returned.

We needed this when we have the deploy branch pushes (https://github.com/alphagov/fastly-configure/pull/15 reverted in https://github.com/alphagov/fastly-configure/pull/16).

Because we pushed to git after the deploy script, `jenkins.sh` exited with a `0` exit code and we didn't notice the deploy had failed (jenkins showed it as green).