### PR TITLE
Don't delete Conditions created in the UI when deploying VCL

### DIFF
--- a/deploy_vcl
+++ b/deploy_vcl
@@ -39,7 +39,7 @@ end
 def delete_ui_objects(service_id, version_number)
   # Delete objects created by the UI. We want VCL to be the source of truth.
   # Most of these don't have real objects in the Fastly API gem.
-  to_delete = %w{backend healthcheck condition cache_settings request_settings response_object header gzip}
+  to_delete = %w{backend healthcheck cache_settings request_settings response_object header gzip}
   to_delete.each do |type|
     type_path = "/service/#{service_id}/version/#{version_number}/#{type}"
     @f.client.get(type_path).map{ |i| i["name"] }.each do |name|


### PR DESCRIPTION
Condition objects are used to restrict which requests are logged for
specific log endpoints. They can’t be configured using VCL, so we
shouldn’t attempt to use the VCL as the source of truth.
Until we have Fastly configured using Terraform, we’ll need to carry on
setting up logging endpoints and related conditions in the UI.

