### PR TITLE
Add A/B tests configuration

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,4 +1,7 @@
 ---
+- name: BenchmarkInlineLink
+  b_percentage: 30
+  expiry: 14d
 - name: SearchMatchLength
   b_percentage: 30
   expiry: 1d

--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,0 +1,4 @@
+---
+- name: SearchMatchLength
+  b_percentage: 30
+  expiry: 1d

--- a/lib/render_template.rb
+++ b/lib/render_template.rb
@@ -1,6 +1,10 @@
+require 'yaml'
+
 class RenderTemplate
   def self.render_template(configuration, environment, config, version)
+    # Both config and ab_tests are used inside the vcl.erb template
     vcl_file = File.join(File.dirname(__FILE__), '..', 'vcl_templates', "#{configuration}.vcl.erb")
+    ab_tests = YAML.load_file(File.join(__dir__, '..', 'ab_tests', 'ab_tests.yaml'))
     ERB.new(File.read(vcl_file), nil, '-').result(binding)
   end
 end


### PR DESCRIPTION
A/B tests should now be added/changed in `ab_tests/ab_tests.yaml`. It is also possible to make changes to the percentage for b group and the expiration time for the cookies. It uses the vcl template (here)[https://github.com/alphagov/govuk-cdn-config/blob/master/vcl_templates/www.vcl.erb] which has had some dynamic rendering added to it in [this PR](alphagov/govuk-cdn-config#52).

We don't take into account multivariate testing at this stage.

Also added configuration for the upcoming `SearchMatchLength`, and `BenchMarkInlineLink` A/B tests.

https://trello.com/c/jsmd99NV/89-prototype-a-b-testing-configuration-changer