### PR TITLE
Set up A/B test for worldwide publishing taxonomy changes

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,3 +1,4 @@
 ---
 - BenchmarkInlineLink
 - SearchMatchLength
+- WorldwidePublishingTaxonomy


### PR DESCRIPTION
This commit sets up the A/B test in Fastly for worldwide publishing taxonomy changes. For 2 weeks, 30% of visitors to worldwide pages will see an alternative, taxonomy-based list of worldwide content rather than the current landing pages, for selected world locations.

Trello: https://trello.com/c/WnkqfojD/124-set-up-a-b-test-in-fastly

See also: https://github.digital.cabinet-office.gov.uk/gds/cdn-configs/pull/128