### PR TITLE
Reduce B group percentage of search A/B test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -3,5 +3,5 @@
   b_percentage: 30
   expiry: 14d
 - name: SearchMatchLength
-  b_percentage: 30
+  b_percentage: 5
   expiry: 1d


### PR DESCRIPTION
Reduce B percentage of `SearchMatchLength` test from 30% to 5% before the test starts because the test should be run with just a small group of users initially.

https://trello.com/c/TVtfR4yD/94-pick-the-first-improvement-for-minimum-should-match-and-start-the-first-a-b-test