### PR TITLE
Change A/B tests configuration

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,7 +1,3 @@
 ---
-- name: BenchmarkInlineLink
-  b_percentage: 30
-  expiry: 14d
-- name: SearchMatchLength
-  b_percentage: 5
-  expiry: 1d
+- BenchmarkInlineLink
+- SearchMatchLength


### PR DESCRIPTION
We no longer set the percentage and expiry in this yaml file, but rather using the Fastly dictionaries. The only thing required in the `ab_tests.yaml` is the name of your test.

[Templating PR](https://github.com/alphagov/govuk-cdn-config/pull/53)
[Dictionaries PR](https://github.digital.cabinet-office.gov.uk/gds/cdn-configs/pull/124)

https://trello.com/c/HOV2ChJ9/104-simplify-a-b-test-cdn-configuration