### PR TITLE
Replace Child Maintenance title A/B test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,5 +1,5 @@
 ---
-- BenchmarkCmTitle1
+- BenchmarkCmTitle2
 - BenchmarkInlineLink
 - EpilepsyDrivingStart
 - SearchMatchLength


### PR DESCRIPTION
This simultaneously desactivates the BenchmarkCmTitle1 A/B test and activates the BenchmarkCmTitle2 one.

Related PRs:
- https://github.digital.cabinet-office.gov.uk/gds/cdn-configs/
- https://github.com/alphagov/smart-answers/pull/3057

[Trello](https://trello.com/c/rcmqkFp3/120-%5Bcm-calculate-title%5D---develop-and-deploy-a%2Fb-test)