### PR TITLE
Remove EpilepsyDrivingStart

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -5,5 +5,4 @@
 - BenchmarkDVLAButton1
 - BenchmarkDVLATitle1
 - BenchmarkInlineLink
-- EpilepsyDrivingStart
 - WorldwidePublishingTaxonomy


### PR DESCRIPTION
[Trello card](https://trello.com/c/Q91ppDXf)

Reverts https://github.com/alphagov/fastly-configure/pull/23

The test ends on 23 June 2016.