### PR TITLE
Remove all Benchmarking tests

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,8 +1,2 @@
 ---
-- BenchmarkALDescription1
-- BenchmarkCmButton1
-- BenchmarkCmTitle2
-- BenchmarkDVLAButton1
-- BenchmarkDVLATitle1
-- BenchmarkInlineLink
 - WorldwidePublishingTaxonomy


### PR DESCRIPTION
We've almost finished testing for now, so we can nearly remove this config.

The last test is scheduled to finish on 27th June, so we should not merge this
before then.

https://trello.com/c/4xlp6cgL/281-clear-up-ab-test-config