### PR TITLE
Add Policies Finder A/B test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,1 +1,2 @@
 ---
+- PolicyFinderTest


### PR DESCRIPTION
Trello card: https://trello.com/c/8Ki1VDSB

Related PRs:
* https://github.com/alphagov/finder-frontend/pull/299
* https://github.digital.cabinet-office.gov.uk/gds/cdn-configs/pull/159

Related Zendesk ticket: https://govuk.zendesk.com/agent/tickets/2303129

## Motivation

There are two policy finders on GOV.UK. The [normal policies finder](https://www.gov.uk/government/policies) and the [all policy content finder](https://www.gov.uk/government/policies/all).

The all policy content finder is hidden to regular users. You have to know the URL to be able to find it. 

This A/B test will provide evidence to help determine which finder provides users with a better journey to find the policy content they are looking for.