### PR TITLE
Remove Policy Finder A/B test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,2 +1,1 @@
 ---
-- PolicyFinderTest


### PR DESCRIPTION
Trello card: https://trello.com/c/v88UNJRy

Related PRs:
* https://github.com/alphagov/cdn-configs/pull/1
* https://github.com/alphagov/finder-frontend/pull/302

Related Zendesk ticket: https://govuk.zendesk.com/agent/tickets/2303129

## Motivation

The A/B test set up to compare The [normal policies finder](https://www.gov.uk/government/policies) and the [all policy content finder](https://www.gov.uk/government/policies/all) finishes on September 13th.