### PR TITLE
Use multivariate test config format for existing tests

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,4 +1,9 @@
+# List the variants for your AB or multivariate test here.
+# Please leave the 'Example' test config in place.
 ---
+- Example:
+  - A
+  - B
 - TaskListSidebar:
   - A
   - B

--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -1,2 +1,4 @@
 ---
-- TaskListSidebar
+- TaskListSidebar:
+  - A
+  - B


### PR DESCRIPTION
Part of https://trello.com/c/gsUWTMyL/34-set-up-infrastructure-for-multi-variant-tests-multi-variant

This PR is the config necessary to enable https://github.com/alphagov/govuk-cdn-config/pull/61
It lists the variants for a given test, in this case the one (disabled) test we currently have configured.
The variants need to be listed explicitly so that we can specify and configure allocations for more than just A & B.