### PR TITLE
Add the TrafficSignsSummary A/B test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -13,3 +13,6 @@
 - TaskListSidebar:
   - A
   - B
+- TrafficSignsSummary:
+  - A
+  - B


### PR DESCRIPTION
The TrafficSignsSummary A/B test will test a content improvement to the
summary of the [Know your traffic signs][1] publication.

[1]: https://www.gov.uk/government/publications/know-your-traffic-signs

## Dependencies:

- [x] https://github.com/alphagov/cdn-configs/pull/9