### PR TITLE
Remove search format weighting A/B test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -4,9 +4,6 @@
 - Example:
   - A
   - B
-- FormatWeighting:
-  - A
-  - B
 - TaskListBrowse:
   - A
   - B


### PR DESCRIPTION
This test is over, so the B version has been rolled out to all users.

https://trello.com/c/8xLTxEUQ/452-deploy-format-weighting-b-version

Marked as "do not merge" until alphagov/finder-frontend#322 has been deployed.