### PR TITLE
Add A/B tests for get-a-divorce tasklist features

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -22,6 +22,12 @@
 - CivilPartnershipTaskListHeader:
   - A
   - B
+- GetADivorceTasklistSidebar:
+  - A
+  - B
+- GetADivorceTaskListHeader:
+  - A
+  - B
 - TrafficSignsSummary:
   - A
   - B


### PR DESCRIPTION
The Modelling Services team are testing the tasklist header and sidebar features for the new tasklist "Get a divorce: step by step"

 Trello card: [Add Fastly tests for get-a-divorce tasklist header and sidebar](https://trello.com/c/QhkM8rLS/) 