### PR TITLE
Add tests for civil-partnership tasklist features

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -13,6 +13,12 @@
 - TaskListSidebar:
   - A
   - B
+- CivilPartnershipTasklistSidebar:
+  - A
+  - B
+- CivilPartnershipTaskListHeader:
+  - A
+  - B
 - TrafficSignsSummary:
   - A
   - B


### PR DESCRIPTION
The Modelling Services team are testing the tasklist header and sidebar features for a new tasklist `End a civil partnership: step by step`.

Trello card: [Add Fastly tests for end-a-civil-partnership tasklist header and sidebar](https://trello.com/c/ahzNdh5h)