### PR TITLE
Remove Traffic signs summary AB test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -28,6 +28,3 @@
 - GetADivorceTaskListHeader:
   - A
   - B
-- TrafficSignsSummary:
-  - A
-  - B


### PR DESCRIPTION
The AB test for the summary on Traffic signs has ended. This undoes https://github.com/alphagov/fastly-configure/pull/44

## Dependencies
- [x] https://github.com/alphagov/government-frontend/pull/577