### PR TITLE
Fix typo in test names

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -16,13 +16,13 @@
 - TaskListSidebar:
   - A
   - B
-- CivilPartnershipTasklistSidebar:
+- CivilPartnershipTaskListSidebar:
   - A
   - B
 - CivilPartnershipTaskListHeader:
   - A
   - B
-- GetADivorceTasklistSidebar:
+- GetADivorceTaskListSidebar:
   - A
   - B
 - GetADivorceTaskListHeader:


### PR DESCRIPTION
This test name should match the original test name for casing ("TaskList") and
also match [govuk_navigation_helpers][nav].

[nav]: https://github.com/alphagov/govuk_navigation_helpers/blob/c57a76d3e613e563cf075d49afe2a61ad3bd4b3a/lib/govuk_navigation_helpers/current_tasklist_ab_test.rb#L25