### PR TITLE
Remove Contextual Comms A/B test config

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -4,7 +4,3 @@
 - Example:
   - A
   - B
-- ContextualComms:
-  - NoCampaign
-  - BlueBoxCampaign
-  - NativeCampaign


### PR DESCRIPTION
This test has finished so the config needs to be removed.