### PR TITLE
Add the ViewDrivingLicence A/B test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -4,3 +4,6 @@
 - Example:
   - A
   - B
+- ViewDrivingLicence:
+  - A
+  - B


### PR DESCRIPTION
This commit adds a new “ViewDrivingLicence” A/B test. The A/B test is defined in https://github.com/alphagov/cdn-configs/pull/56.

Trello: https://trello.com/c/7yUyibkE/323-add-a-b-test-for-view-driving-licence