### PR TITLE
Remove content pages AB test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -4,9 +4,6 @@
 - Example:
   - A
   - B
-- ContentPagesNav:
-  - A
-  - B
 - ViewDrivingLicence:
   - A
   - B


### PR DESCRIPTION
The test has finished.

Following instructions in [the developer docs](https://docs.publishing.service.gov.uk/manual/ab-testing.html#4-how-to-tear-down-an-ab-test)

https://trello.com/c/ur3nYBPJ/166-to-remove-our-content-pages-experiment-from-the-a-b-framework