### PR TITLE
Add related links A/A test

### DIFF
--- a/ab_tests/ab_tests.yaml
+++ b/ab_tests/ab_tests.yaml
@@ -13,3 +13,6 @@
 - ViewDrivingLicence:
   - A
   - B
+- RelatedLinksAATest:
+  - A
+  - B


### PR DESCRIPTION
This PR updates the A/B tests config file to add new test `RelatedLinksAATest`.

Related to https://github.com/alphagov/fastly-configure/pull/69

https://trello.com/c/dkIgHjmc/207-to-get-an-a-a-test-running-on-govuk